### PR TITLE
fix: error constant to string

### DIFF
--- a/mailreflector.php
+++ b/mailreflector.php
@@ -10,8 +10,8 @@ if ($fh === FALSE)
 $ba = array();
 $clients=array();
 stream_set_blocking($fh, 0);
-define(EOF, "\n");
-define(LOGIN_LIMIT, "15724800");
+define("EOF", "\n");
+define("LOGIN_LIMIT", "15724800");
 
 $redis = new Redis();
 $doconnect = true;


### PR DESCRIPTION
The current implementation of the `mailreflector.php` returns the following error when building with the latest `php:alpine` image:

```error
[reflector] | Fatal error: Uncaught Error: Undefined constant "EOF" in /mailreflector.php:13
[reflector] | Stack trace:
[reflector] | #0 {main}
[reflector] |   thrown in /mailreflector.php on line 13
```

Solution:
Add double quotes to the constants. Check [PHP Docs](https://www.php.net/manual/en/language.constants.php) for reference.

Note:
The code was tested on a Macbook Air M3 using `podman-compose`.